### PR TITLE
Add Escape to list of ignored keys for AutoComplete

### DIFF
--- a/AutocompleteMenu/AutocompleteMenu.cs
+++ b/AutocompleteMenu/AutocompleteMenu.cs
@@ -522,6 +522,7 @@ namespace AutocompleteMenuNS
                     case Keys.End:
                     case Keys.Home:
                     case Keys.ControlKey:
+                    case Keys.Escape:
                         {
                             timer.Stop();
                             return;


### PR DESCRIPTION
This fixes a crash when the editor is placed inside a popup window (which will close on Escape). The control will then be disposed, but the timer will not be stopped properly, resulting in a crash.